### PR TITLE
Fix faulty test in Chapter 6

### DIFF
--- a/ch6-blog-app-with-forms/blog/tests.py
+++ b/ch6-blog-app-with-forms/blog/tests.py
@@ -53,8 +53,6 @@ class BlogTests(TestCase):
             'author': self.user.id,
         })
         self.assertEqual(response.status_code, 302)
-        self.assertContains(response, 'New title')
-        self.assertContains(response, 'New text')
 
     def test_post_update_view(self):
         response = self.client.post(reverse('post_edit', args='1'), {

--- a/ch6-blog-app-with-forms/blog/tests.py
+++ b/ch6-blog-app-with-forms/blog/tests.py
@@ -50,9 +50,9 @@ class BlogTests(TestCase):
         response = self.client.post(reverse('post_new'), {
             'title': 'New title',
             'body': 'New text',
-            'author': self.user,
+            'author': self.user.id,
         })
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 302)
         self.assertContains(response, 'New title')
         self.assertContains(response, 'New text')
 


### PR DESCRIPTION
Currently, the POST request which is sent does not result in the form being submitted successfully; that's because the POST request sent to the `CreateView` should include the author's id (and not the string representation of author). You can print the `response` variable in the test method and run the tests in verbose mode to see the form errors in HTML output of the page (`python manage.py test -v 3`). 

Further, since `CreateView` like `UpdateView` and `DeleteView` redirects to another page upon success, the expected status code should be `302`. This also invalidates the content assertions checks, and therefore they should be removed.

Note that the relevant section in the book (both the code and the explanations after it) needs to be corrected as well.